### PR TITLE
Fix in 2.22

### DIFF
--- a/analysis/3sem/5.tex
+++ b/analysis/3sem/5.tex
@@ -425,7 +425,7 @@ $$f'(a) - \lambda\Phi'(a) = 0 \Leftrightarrow G'(a) = 0$$
     \end{itemize}
     Тогда $||A|| = \max\{\sqrt{\lambda} : \lambda \text{ --- собственное число } A^TA\}$
 
-    Такое число существует, т.к. $\langle Ax, y\rangle = \langle x, Ay\rangle \Rightarrow \langle A^T Ax, x\rangle = \langle Ax, Ax\rangle \ge 0 \Rightarrow \lambda \ge 0$.
+     Такое число существует, т.к. $\langle Ax, y\rangle = \langle x, A^Ty\rangle \Rightarrow \langle A^T Ax, x\rangle = \langle Ax, Ax\rangle \ge 0 \Rightarrow \lambda \ge 0$.
     %</нормалоп>
 \end{theorem}
 %<*нормалопproof>


### PR DESCRIPTION
Во второй скобке должно быть транспонирование:
<Ax, y> = <x, A<sup>T</sup>y>